### PR TITLE
Fix sign in with Google

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -31,7 +31,7 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '8.11.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '8.14.0'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -27,7 +27,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.803265650064-kcjnombfdv53pd8f6uabsudr0ikdqsaj</string>
+				<string>com.googleusercontent.apps.803265650064-as3usri2iu8eba80tgdmrklvr2tvmtm6</string>
 			</array>
 		</dict>
 	</array>

--- a/lib/config/auth_providers.dart
+++ b/lib/config/auth_providers.dart
@@ -1,0 +1,10 @@
+import 'package:flutterfire_ui/auth.dart';
+
+const kGoogleClientId =
+    '803265650064-n8euv0sb8rcd1vrl8q49nj8p7e9qnr64.apps.googleusercontent.com';
+
+const List<ProviderConfiguration> providerConfigs = [
+  EmailProviderConfiguration(),
+  GoogleProviderConfiguration(clientId: kGoogleClientId),
+  AppleProviderConfiguration(),
+];

--- a/lib/config/auth_providers.dart
+++ b/lib/config/auth_providers.dart
@@ -1,7 +1,7 @@
 import 'package:flutterfire_ui/auth.dart';
 
 const kGoogleClientId =
-    '803265650064-n8euv0sb8rcd1vrl8q49nj8p7e9qnr64.apps.googleusercontent.com';
+    '803265650064-as3usri2iu8eba80tgdmrklvr2tvmtm6.apps.googleusercontent.com';
 
 const List<ProviderConfiguration> providerConfigs = [
   EmailProviderConfiguration(),

--- a/lib/config/auth_providers.dart
+++ b/lib/config/auth_providers.dart
@@ -1,10 +1,16 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
 import 'package:flutterfire_ui/auth.dart';
 
-const kGoogleClientId =
-    '803265650064-as3usri2iu8eba80tgdmrklvr2tvmtm6.apps.googleusercontent.com';
+// For some reason, the client ID for iOS is different than for Web and Android
+// The `kIsWeb` has to be the first check as `Platform` is not available in web
+final kGoogleClientId = kIsWeb || Platform.isAndroid
+    ? '803265650064-n8euv0sb8rcd1vrl8q49nj8p7e9qnr64.apps.googleusercontent.com'
+    : '803265650064-as3usri2iu8eba80tgdmrklvr2tvmtm6.apps.googleusercontent.com';
 
-const List<ProviderConfiguration> providerConfigs = [
-  EmailProviderConfiguration(),
+final List<ProviderConfiguration> providerConfigs = [
+  const EmailProviderConfiguration(),
   GoogleProviderConfiguration(clientId: kGoogleClientId),
-  AppleProviderConfiguration(),
+  const AppleProviderConfiguration(),
 ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,18 @@
+import 'package:andax/config/auth_providers.dart';
 import 'package:andax/config/themes.dart';
 import 'package:andax/firebase_options.dart';
 import 'package:andax/modules/home/screens/home.dart';
 import 'package:andax/store.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutterfire_ui/auth.dart';
 
 import 'modules/home/screens/splash.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  FlutterFireUIAuth.configureProviders(providerConfigs);
   runApp(const App());
 }
 

--- a/lib/modules/profile/config/auth_providers.dart
+++ b/lib/modules/profile/config/auth_providers.dart
@@ -1,9 +1,0 @@
-import 'package:andax/firebase_options.dart';
-import 'package:flutterfire_ui/auth.dart';
-
-final List<ProviderConfiguration> providerConfigs = [
-  const EmailProviderConfiguration(),
-  // GoogleProviderConfiguration(
-      // clientId: DefaultFirebaseOptions.currentPlatform.appId),
-  const AppleProviderConfiguration(),
-];

--- a/lib/modules/profile/screens/sign_in.dart
+++ b/lib/modules/profile/screens/sign_in.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutterfire_ui/auth.dart' as flutterfire_auth;
 
-import '../config/auth_providers.dart';
-
 class SignInScreen extends StatelessWidget {
   const SignInScreen({Key? key}) : super(key: key);
 
@@ -10,9 +8,7 @@ class SignInScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Sign In or Register')),
-      body: flutterfire_auth.SignInScreen(
-        providerConfigs: providerConfigs,
-      ),
+      body: const flutterfire_auth.SignInScreen(),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,28 +7,28 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "36.0.0"
+    version: "38.0.0"
   algolia:
     dependency: "direct main"
     description:
       name: algolia
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.1"
+    version: "3.4.1"
   archive:
     dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.0"
   args:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.7"
+    version: "2.1.8"
   build_runner_core:
     dependency: transitive
     description:
@@ -147,21 +147,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.10"
+    version: "3.1.11"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.5.1"
+    version: "5.5.2"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.10"
+    version: "2.6.11"
   code_builder:
     dependency: transitive
     description:
@@ -196,14 +196,14 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   desktop_webview_auth:
     dependency: transitive
     description:
       name: desktop_webview_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.5"
+    version: "0.0.6"
   email_validator:
     dependency: transitive
     description:
@@ -231,28 +231,28 @@ packages:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.9"
+    version: "3.3.12"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.1"
+    version: "6.2.2"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.9"
+    version: "3.3.10"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.13.1"
+    version: "1.14.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -273,35 +273,35 @@ packages:
       name: firebase_database
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.8"
+    version: "9.0.9"
   firebase_database_platform_interface:
     dependency: transitive
     description:
       name: firebase_database_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.1+2"
   firebase_database_web:
     dependency: transitive
     description:
       name: firebase_database_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+7"
+    version: "0.2.0+8"
   firebase_dynamic_links:
     dependency: transitive
     description:
       name: firebase_dynamic_links
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.8"
+    version: "4.1.2"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.2+2"
   fixnum:
     dependency: transitive
     description:
@@ -320,7 +320,7 @@ packages:
       name: flutter_facebook_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   flutter_facebook_auth_platform_interface:
     dependency: transitive
     description:
@@ -360,7 +360,7 @@ packages:
       name: flutter_markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.9"
+    version: "0.6.9+1"
   flutter_svg:
     dependency: transitive
     description:
@@ -384,7 +384,7 @@ packages:
       name: flutterfire_ui
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.5+1"
+    version: "0.4.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -482,7 +482,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   json_annotation:
     dependency: "direct main"
     description:
@@ -496,7 +496,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4"
+    version: "6.1.5"
   lints:
     dependency: transitive
     description:
@@ -566,7 +566,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   path_drawing:
     dependency: transitive
     description:
@@ -622,7 +622,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
@@ -643,7 +643,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -753,7 +753,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   sign_in_with_apple: ^3.3.0
   crypto: ^3.0.1
   json_annotation: ^4.4.0
-  flutterfire_ui: ^0.3.2
+  flutterfire_ui: ^0.4.0
   badges: ^2.0.2
   provider: ^6.0.2
   url_launcher: ^6.0.20


### PR DESCRIPTION
That was a long road due to the obscurity (or even lack) of error messages, but here we are at last. Redirect URLs and app/bundle IDs have been configured in both Firebase and GCP, and platform-specific client IDs are now set up properly.
I have no idea why the iOS client ID is different, or why the Web and Android are both the same, but it is what it is for now as I wasted too much time on it already.

I have ensured that it works on web (localhost), iOS (simulator), and Android (dev mode only. couldn't build for production as I didn't configure my signing keys yet).

Closes #31 as well since I was doing changes in this area anyway