### PR TITLE
Terminology refactor

### DIFF
--- a/lib/models/translation.dart
+++ b/lib/models/translation.dart
@@ -23,7 +23,7 @@ class Translation {
   String node(Node? n, {bool allowEmpty = false}) =>
       this[n?.id] ?? (allowEmpty ? '' : '[❌NODE]');
   String transition(Transition? t) => this[t?.id] ?? '[❌TRANSITION]';
-  String actor(Actor? a) => this[a?.id] ?? '[❌ACTOR]';
+  String actor(Actor? a) => this[a?.id] ?? '[❌CHARACTER]';
   String cell(Cell? c) => this[c?.id] ?? '[❌CELL]';
   String audio(Node? n) => this['${n?.id}_audio'] ?? '';
 

--- a/lib/models/translation.dart
+++ b/lib/models/translation.dart
@@ -21,7 +21,7 @@ class Translation {
   void operator []=(String id, String asset) => assets[id] = asset;
 
   String node(Node? n, {bool allowEmpty = false}) =>
-      this[n?.id] ?? (allowEmpty ? '' : '[❌NODE]');
+      this[n?.id] ?? (allowEmpty ? '' : '[❌MESSAGE]');
   String transition(Transition? t) => this[t?.id] ?? '[❌TRANSITION]';
   String actor(Actor? a) => this[a?.id] ?? '[❌CHARACTER]';
   String cell(Cell? c) => this[c?.id] ?? '[❌CELL]';

--- a/lib/modules/editor/screens/actors.dart
+++ b/lib/modules/editor/screens/actors.dart
@@ -28,14 +28,14 @@ class ActorsEditorScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         leading: const RoundedBackButton(),
-        title: const Text('Story actors'),
+        title: const Text('Story character'),
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => showActorEditor(
           context,
         ).then((r) => onSelect(r, true)),
         icon: const Icon(Icons.person_add_rounded),
-        label: const Text('Add actor'),
+        label: const Text('Add a character'),
       ),
       body: CustomScrollView(
         controller: scroll,

--- a/lib/modules/editor/screens/narrative.dart
+++ b/lib/modules/editor/screens/narrative.dart
@@ -96,7 +96,7 @@ class _NarrativeEditorScreenState extends State<NarrativeEditorScreen> {
           setState(() {});
         },
         icon: const Icon(Icons.add_circle_rounded),
-        label: const Text('Add node'),
+        label: const Text('Add a message'),
       ),
       body: ListView.builder(
         padding: const EdgeInsets.only(bottom: 76),

--- a/lib/modules/editor/screens/node.dart
+++ b/lib/modules/editor/screens/node.dart
@@ -149,7 +149,7 @@ class _NodeEditorScreenState extends State<NodeEditorScreen>
           for (var i = 0; i < transitions.length; i++)
             ListTile(
               title: Text(
-                editor.tr[transitions[i].targetNodeId] ?? '[❌NODE]',
+                editor.tr[transitions[i].targetNodeId] ?? '[❌MESSAGE]',
               ),
               subtitle: editor.tr[transitions[i].id] == null
                   ? null
@@ -209,13 +209,13 @@ class _NodeEditorScreenState extends State<NodeEditorScreen>
     return Scaffold(
       appBar: AppBar(
         leading: const RoundedBackButton(icon: Icons.done_all_rounded),
-        title: const Text('Node editor'),
+        title: const Text('Messages editor'),
         actions: [
           OptionsButton(
             [
               OptionItem.simple(
                 Icons.delete_rounded,
-                'Delete node',
+                'Delete message',
                 () => deleteNode(
                   context,
                   node,

--- a/lib/modules/editor/screens/story.dart
+++ b/lib/modules/editor/screens/story.dart
@@ -121,7 +121,7 @@ class StoryEditorState extends State<StoryEditorScreen> {
                   ),
                   BottomNavigationBarItem(
                     icon: Icon(Icons.groups_rounded),
-                    label: 'Actors',
+                    label: 'Characters',
                   ),
                   BottomNavigationBarItem(
                     icon: Icon(Icons.library_books_rounded),

--- a/lib/modules/editor/utils/node.dart
+++ b/lib/modules/editor/utils/node.dart
@@ -15,7 +15,7 @@ Future<Node> editNode(
     final id = editor.uuid.v4();
     node = Node(id);
     editor.story.nodes[id] = node;
-    editor.tr[id] = 'Node #${editor.story.nodes.length}';
+    editor.tr[id] = 'Message #${editor.story.nodes.length}';
   }
   await Navigator.push<void>(
     context,
@@ -36,7 +36,7 @@ void deleteNode(
   Node node, [
   VoidCallback? onDone,
 ]) async {
-  if (await showDangerDialog(context, 'Delete node?')) {
+  if (await showDangerDialog(context, 'Delete message?')) {
     final editor = context.read<StoryEditorState>();
     editor.story.nodes.remove(node.id);
     editor.tr.assets.remove(node.id);

--- a/lib/modules/editor/widgets/actor_editor.dart
+++ b/lib/modules/editor/widgets/actor_editor.dart
@@ -16,7 +16,7 @@ Future<Actor?> showActorEditor(
   if (value == null) {
     final id = editor.uuid.v4();
     actor = Actor(id);
-    name = 'Actor #${editor.story.actors.length + 1}';
+    name = 'Character #${editor.story.actors.length + 1}';
   } else {
     actor = Actor.fromJson(value.toJson());
     name = editor.tr.actor(actor);
@@ -24,7 +24,7 @@ Future<Actor?> showActorEditor(
 
   return showEditorSheet<Actor>(
     context: context,
-    title: value == null ? 'Create actor' : 'Edit actor',
+    title: value == null ? 'Create a character' : 'Edit character',
     initial: value,
     onSave: () {
       editor.story.actors[actor.id] = actor;
@@ -46,7 +46,7 @@ Future<Actor?> showActorEditor(
           leading: const Icon(Icons.label_rounded),
           title: TextFormField(
             decoration: const InputDecoration(
-              labelText: 'Actor name',
+              labelText: 'Character name',
             ),
             autofocus: true,
             initialValue: name,
@@ -67,7 +67,7 @@ Future<Actor?> showActorEditor(
         ),
         buildExplanationTile(
           context,
-          'Actor mode',
+          'Character mode',
           'Sets the look of its messages, restricts some options for them.',
         ),
         RadioListTile<ActorType>(
@@ -75,7 +75,7 @@ Future<Actor?> showActorEditor(
           groupValue: actor.type,
           onChanged: setType,
           secondary: const Icon(Icons.smart_toy_rounded),
-          title: const Text('Computer actor'),
+          title: const Text('Computer character'),
           subtitle: const Text('Follows the narrative'),
         ),
         RadioListTile<ActorType>(
@@ -83,7 +83,7 @@ Future<Actor?> showActorEditor(
           groupValue: actor.type,
           onChanged: setType,
           secondary: const Icon(Icons.face_rounded),
-          title: const Text('Player actor'),
+          title: const Text('Player character'),
           subtitle: const Text('Controlled by the player'),
         ),
       ];

--- a/lib/modules/editor/widgets/node_tile.dart
+++ b/lib/modules/editor/widgets/node_tile.dart
@@ -31,7 +31,7 @@ class NodeTile extends StatelessWidget {
   Widget build(BuildContext context) {
     if (node == null) {
       return const ListTile(
-        title: Text('[MISSING NODE]'),
+        title: Text('[MISSING MESSAGE]'),
       );
     }
     final editor = context.watch<StoryEditorState>();

--- a/lib/modules/editor/widgets/transition_editor.dart
+++ b/lib/modules/editor/widgets/transition_editor.dart
@@ -79,7 +79,7 @@ Future<Transition?> showTransitionEditor(
               onChanged: (s) => label = s.trim(),
             ),
           ),
-        buildExplanationTile(context, 'Target node'),
+        buildExplanationTile(context, 'Target message'),
         Provider.value(
           value: editor,
           child: NodeTile(

--- a/lib/modules/translation/screens/translations.dart
+++ b/lib/modules/translation/screens/translations.dart
@@ -85,7 +85,7 @@ class TranslationEditorState extends State<TranslationEditorScreen> {
                   Asset('description', icon: Icons.description_rounded),
                   // ignore: prefer_const_constructors
                   Asset('tags', icon: Icons.tag_rounded),
-                  buildExplanationTile(context, 'Actors'),
+                  buildExplanationTile(context, 'Characters'),
                   for (final aid in narrative.actors.keys)
                     Asset(aid, icon: Icons.person_rounded),
                   buildExplanationTile(context, 'Cells'),


### PR DESCRIPTION
Related to #54 
Renames only "**Node**" and "**Actor**", but not "**Cell**" because I couldn't find a better word to represent it. However, I believe the concept itself is still a little difficult for users (especially since it can do many things at once, such as holding a range/numeric/string value, or even be used for internal logic) and needs to be broken down further.